### PR TITLE
adding unitless dimensions for lansen devices (0x3a)

### DIFF
--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -2554,6 +2554,11 @@ mbus_vib_unit_lookup(mbus_value_information_block *vib)
             // VIFE = E111 nnn Reserved
             snprintf(buff, sizeof(buff), "Reserved VIF extension");
         }
+        else if (vib->vife[0] == 0x3A)
+        {
+            // Unitless dimension (eg. Lansen Pulse Counter)
+            snprintf(buff, sizeof(buff), "Unitless Dimension");
+        }
         else
         {
             snprintf(buff, sizeof(buff), "Unrecognized VIF extension: 0x%.2x", vib->vife[0]);


### PR DESCRIPTION
adding a handler for unitless dimensions sent by lansen OMS devices like Lansen Pulse Counter.
formerly the vif has been identified as _unknown_ which gets ignored by pymbus later down the line.
this creates a new unit called "unitless dimension", which will be processed by pymbus by default.